### PR TITLE
[Robot] Added a fast and a slow mode to drive

### DIFF
--- a/Robot/src/main/java/com/swrobotics/robot/RobotContainer.java
+++ b/Robot/src/main/java/com/swrobotics/robot/RobotContainer.java
@@ -86,10 +86,12 @@ public class RobotContainer {
         // Right stick X axis -> rotation
         drivetrainSubsystem.setDefaultCommand(new DefaultDriveCommand(
                 drivetrainSubsystem,
-                () -> -modifyAxis(controller.getLeftY()) * DrivetrainSubsystem.MAX_ACHIEVABLE_VELOCITY_METERS_PER_SECOND,
-                () -> -modifyAxis(controller.getLeftX()) * DrivetrainSubsystem.MAX_ACHIEVABLE_VELOCITY_METERS_PER_SECOND,
+                () -> -modifyAxis(controller.getLeftY()) * (DrivetrainSubsystem.MAX_ACHIEVABLE_VELOCITY_METERS_PER_SECOND / 2),
+                () -> -modifyAxis(controller.getLeftX()) * (DrivetrainSubsystem.MAX_ACHIEVABLE_VELOCITY_METERS_PER_SECOND / 2),
                 () -> -modifyAxis(controller.getRightX())
-                        * DrivetrainSubsystem.MAX_ANGULAR_VELOCITY_RADIANS_PER_SECOND));
+                * DrivetrainSubsystem.MAX_ANGULAR_VELOCITY_RADIANS_PER_SECOND,
+                () -> controller.getLeftBumper(),
+                () -> controller.getRightBumper()));
 
         // Configure the rest of the button bindings
         configureButtonBindings();

--- a/Robot/src/main/java/com/swrobotics/robot/commands/DefaultDriveCommand.java
+++ b/Robot/src/main/java/com/swrobotics/robot/commands/DefaultDriveCommand.java
@@ -4,25 +4,36 @@ import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 
+import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
 
 import com.swrobotics.robot.subsystems.drive.DrivetrainSubsystem;
 
 public class DefaultDriveCommand extends CommandBase {
+    private static final double SLOW_MODE_MULTIPLIER = 0.5;
+    private static final double FAST_MODE_MULTIPLIER = 2.0;
+
     private final DrivetrainSubsystem drivetrainSubsystem;
 
     private final DoubleSupplier translationXSupplier;
     private final DoubleSupplier translationYSupplier;
     private final DoubleSupplier rotationSupplier;
 
+    private final BooleanSupplier slowModeSupplier;
+    private final BooleanSupplier fastModeSupplier;
+
     public DefaultDriveCommand(DrivetrainSubsystem drive,
                                DoubleSupplier translationXSupplier,
                                DoubleSupplier translationYSupplier,
-                               DoubleSupplier rotationSupplier) {
+                               DoubleSupplier rotationSupplier,
+                               BooleanSupplier slowModeSupplier,
+                               BooleanSupplier fastModeSupplier) {
         this.drivetrainSubsystem = drive;
         this.translationXSupplier = translationXSupplier;
         this.translationYSupplier = translationYSupplier;
         this.rotationSupplier = rotationSupplier;
+        this.slowModeSupplier = slowModeSupplier;
+        this.fastModeSupplier = fastModeSupplier;
 
         addRequirements(drive);
     }
@@ -31,11 +42,24 @@ public class DefaultDriveCommand extends CommandBase {
     public void execute() {
         // You can use `new ChassisSpeeds(...)` for robot-oriented movement instead of field-oriented movement
 
+        double multiplier = 1.0;
+
+        if (slowModeSupplier.getAsBoolean()) {
+            multiplier *= SLOW_MODE_MULTIPLIER;
+        }
+
+        if (fastModeSupplier.getAsBoolean()) {
+            multiplier *= FAST_MODE_MULTIPLIER;
+        }
+
+        double x = translationXSupplier.getAsDouble() * multiplier;
+        double y = translationYSupplier.getAsDouble() * multiplier;
+
         if (RobotBase.isSimulation()) {
             drivetrainSubsystem.setChassisSpeeds(
                 ChassisSpeeds.fromFieldRelativeSpeeds(
-                        translationXSupplier.getAsDouble(),
-                        translationYSupplier.getAsDouble(),
+                        x,
+                        y,
                         rotationSupplier.getAsDouble(),
                         drivetrainSubsystem.getPose().getRotation()
                 )
@@ -45,8 +69,8 @@ public class DefaultDriveCommand extends CommandBase {
 
         drivetrainSubsystem.setChassisSpeeds(
                 ChassisSpeeds.fromFieldRelativeSpeeds(
-                        translationXSupplier.getAsDouble(),
-                        translationYSupplier.getAsDouble(),
+                        x,
+                        y,
                         rotationSupplier.getAsDouble(),
                         drivetrainSubsystem.getGyroscopeRotation()
                 )


### PR DESCRIPTION
This binds the bumpers to speed modes. By default, the robot will cap at 50% speed. There is a fast mode to uncap the speed and a slow mode to slow it down for precise movement. The bindings are a little bad so we will need Nathan to choose his preference.

Tested and working in the sim, it shouldn't be any different on the actual robot.

The multipliers will need to be tuned and probably should be NT values (or just leave them as constants so they never break)