### PR TITLE
[Robot] Prevent arm from slamming into the grid

### DIFF
--- a/Robot/src/main/java/com/swrobotics/robot/input/Input.java
+++ b/Robot/src/main/java/com/swrobotics/robot/input/Input.java
@@ -26,8 +26,8 @@ public final class Input extends SubsystemBase {
     private static final double DEADBAND = 0.1;
 
     private static final double SLOW_MODE_MULTIPLIER = 0.5;
-    private static final double FAST_MODE_MULTIPLIER = 2.0;
-    private static final Angle MAX_ROTATION = AbsoluteAngle.rad(Math.PI / 2);
+    private static final double FAST_SPEED = 4.11;
+    private static final Angle MAX_ROTATION = AbsoluteAngle.rad(Math.PI);
 
     private static final double NUDGE_PER_PERIODIC = 0.25 * 0.02;
 
@@ -42,6 +42,8 @@ public final class Input extends SubsystemBase {
 
     private Translation2d prevArmTarget;
     private Translation2d armNudge;
+
+    private double lastSpeed = 0;
 
     public Input(RobotContainer robot) {
         this.robot = robot;
@@ -69,14 +71,22 @@ public final class Input extends SubsystemBase {
 //        boolean slowMode = driver.leftBumper.isPressed();
         boolean fastMode = driver.rightBumper.isPressed();
 
-        double multiplier = 1;
+        double speed = 1.5;
 //        if (slowMode)
 //            multiplier *= SLOW_MODE_MULTIPLIER;
-        if (fastMode)
-            multiplier *= FAST_MODE_MULTIPLIER;
+        if (fastMode) {
+            speed = FAST_SPEED;
+        }
 
-        double x = -deadband(driver.leftStickY.get()) * multiplier;
-        double y = -deadband(driver.leftStickX.get()) * multiplier;
+        if (speed != lastSpeed) {
+            speed = (speed + lastSpeed) / 2;
+            // FIXME: Accual decceleration
+        }
+
+        lastSpeed = speed;
+
+        double x = -deadband(driver.leftStickY.get()) * speed;
+        double y = -deadband(driver.leftStickX.get()) * speed;
 
         return new Vec2d(x, y);
     }
@@ -198,8 +208,8 @@ public final class Input extends SubsystemBase {
 
         // Update arm nudge
         armNudge = armNudge.plus(new Translation2d(
-            deadband(manipulator.leftStickX.get()) * NUDGE_PER_PERIODIC,
-            deadband(-manipulator.leftStickY.get()) * NUDGE_PER_PERIODIC
+            deadband(manipulator.rightStickX.get()) * NUDGE_PER_PERIODIC,
+            deadband(-manipulator.rightStickY.get()) * NUDGE_PER_PERIODIC
             ));
 
         Translation2d armTarget = getArmTarget();


### PR DESCRIPTION
This PR forces the arm to move up first before moving over or over first before moving down. Instead of taking the most direct path, it takes a path that shouldn't hit the grid if we start moving it while close to the snap point.

Tested and working in the simulator.